### PR TITLE
accept 'OK' for disk health

### DIFF
--- a/files/default/checks/check-smart.rb
+++ b/files/default/checks/check-smart.rb
@@ -74,7 +74,7 @@ class Disk
   #
   def check_health!
     output = `sudo smartctl -H #{@device_path}`
-    @smart_healthy = !output.scan(/PASSED/).empty?
+    @smart_healthy = !output.scan(/PASSED|OK$/).empty?
     @health_output = output
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'christian.graf@realzeitmedia.com'
 license          'Apache 2.0'
 description      'Installs/Configures Sensu checks, handlers, etc. using community plugins'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.21'
+version          '0.1.22'
 
 depends 'sensu'


### PR DESCRIPTION
One disk:
```
=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED
```
Other disk:

```
=== START OF READ SMART DATA SECTION ===
SMART Health Status: OK
```